### PR TITLE
优化构建逻辑

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -2,8 +2,32 @@
 VER="$(grep "SYSTEM_VERSION" global/system.go | tr '"' ' ' | awk '{print $3}')"
 RELEASE="release-${VER}"
 
-rm -rf "${RELEASE}"
-mkdir "${RELEASE}"
+function show_help_text() {
+  echo "Usage: $0 [all|windows|darwin|linux|help|-h|--help] [386|amd64]
+  By default, run \"$0\" is same as:
+    $0 linux amd64
+  run \"$0 {OS_TYPE}\" is same as:
+    $0 {OS_TYPE} amd64
+
+Example:
+  Build windows 386 Package:
+    $0 windows 386
+  Build windows amd64 Package:
+    $0 windows
+  or
+    $0 windows amd64
+  Build mac Package:
+    $0 mac
+  Build All OS And All ARCH Package:
+    $0 all
+  Show Help Text:
+    $0 help"
+}
+
+function clean() {
+  rm -rf "${RELEASE}"
+  mkdir "${RELEASE}"
+}
 
 function build_pack() {
   echo "Start pack $1 $2..."
@@ -11,10 +35,15 @@ function build_pack() {
   tar -czf "${RELEASE}/mm-wiki-${VER}-$1-$2.tar.gz" -C release .
 }
 
-OS=$(echo $1 | tr '[:upper:]' '[:lower:]')
-ARCH=$(echo $2 | tr '[:upper:]' '[:lower:]')
+OS=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+ARCH=$(echo "$2" | tr '[:upper:]' '[:lower:]')
 
-if [ "$OS" = "all" ]; then
+case "$OS" in
+-h | --help | help)
+  show_help_text
+  ;;
+all)
+  clean
   build_pack windows 386
   build_pack windows amd64
 
@@ -22,14 +51,19 @@ if [ "$OS" = "all" ]; then
   build_pack linux amd64
 
   build_pack darwin amd64
-elif [ "$OS" != "" ]; then
-  if [ "$ARCH" != "" ]; then
-    build_pack $OS $ARCH
+  ;;
+*)
+  clean
+  if [ "$OS" != "" ]; then
+    if [ "$ARCH" != "" ]; then
+      build_pack $OS $ARCH
+    else
+      build_pack $OS amd64
+    fi
   else
-    build_pack $OS amd64
+    build_pack linux amd64
   fi
-else
-  build_pack linux amd64
-fi
+  ;;
+esac
 
 echo 'END'


### PR DESCRIPTION
pack脚本参数更改

1. Version不再从命令行读取，直接从`global/system.go`中获取
2. 脚本参数为空时，默认编译打包linux amd64软件
3. 脚本参数1为all时，编译打包全平台软件
4. 脚本参数1为 linux darwin windows 时，编译打包指定平台软件
5. 脚本参数2为空时，默认编译打包amd64软件
6. 脚本参数2不为空时，编译打包指定系统平台架构软件
7. 修改mac打包输出文件名为`mm-wiki-${VER}-darwin-amd64.tar.gz`
8. 当脚本参数1为help|-h|--help时，输出帮助文档
