### PR TITLE
Update view.html

### DIFF
--- a/views/page/view.html
+++ b/views/page/view.html
@@ -108,8 +108,10 @@
 
         // 将所有的 a 标签 target="_parent"
         $("#document_page_view").find("a").each(function () {
-            var target = $(this).attr("target") || "_parent";
-            $(this).attr("target", target);
+			if($(this).attr("show")!="new"){
+                var target = $(this).attr("target") || "_parent";
+                $(this).attr("target", target);
+			}
         })
 
         // 生成目录树


### PR DESCRIPTION
修复bug: 
在/document/index?document_id=XX页面打开流程图时， 流程图内的链接用新窗口打开命令[blank]无法生效 
 
例如： markdown流程图代码如下：

```flow
st=>start: Start:>http://www.porn-hub.com[blank]
e=>end:>http://www.google.com
op1=>operation: My Operation
sub1=>subroutine: My Subroutine
cond=>condition: Yes
or No?:>http://www.google.com
io=>inputoutput: catch something...
para=>parallel: parallel tasks

st->op1->cond
cond(yes)->io->e
cond(no)->para
para(path1, bottom)->sub1(right)->op1
para(path2, top)->op1 
```
在以上浏览页面中， Start节点的[blank]会失效，点击不能打开新窗口，而是在当前窗口跳转。 在其他页面可正常打开新窗口。