### PR TITLE
在网页标题中添加系统名称

### DIFF
--- a/views/layouts/attachment.html
+++ b/views/layouts/attachment.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/layouts/author.html
+++ b/views/layouts/author.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <title>MM-Wiki - Login</title>
+    <title>{{.system_name}} | MM-Wiki - Login</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link href="/static/plugins/bootstrap/css/bootstrap.min.css" rel="stylesheet">

--- a/views/layouts/default.html
+++ b/views/layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/layouts/document.html
+++ b/views/layouts/document.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- bootstrap css -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/layouts/document_page.html
+++ b/views/layouts/document_page.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link href="/static/plugins/bootstrap/css/bootstrap.min.css" rel="stylesheet">

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="wiki markdown">
     <meta name="author" content="phachon">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- bootstrap css -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/layouts/page.html
+++ b/views/layouts/page.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- bootstrap css -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/layouts/space.html
+++ b/views/layouts/space.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- bootstrap css -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/layouts/user.html
+++ b/views/layouts/user.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- bootstrap css -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/auth.html
+++ b/views/system/layouts/auth.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/config.html
+++ b/views/system/layouts/config.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/contact.html
+++ b/views/system/layouts/contact.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/default.html
+++ b/views/system/layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/email.html
+++ b/views/system/layouts/email.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/link.html
+++ b/views/system/layouts/link.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/log.html
+++ b/views/system/layouts/log.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/main.html
+++ b/views/system/layouts/main.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- bootstrap css -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/plugin.html
+++ b/views/system/layouts/plugin.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/privilege.html
+++ b/views/system/layouts/privilege.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/profile.html
+++ b/views/system/layouts/profile.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/role.html
+++ b/views/system/layouts/role.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/space.html
+++ b/views/system/layouts/space.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/static.html
+++ b/views/system/layouts/static.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">

--- a/views/system/layouts/user.html
+++ b/views/system/layouts/user.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1 , user-scalable=no">
-    <title>MM-Wiki</title>
+    <title>{{.system_name}} | MM-Wiki</title>
     <link type="favicon" rel="shortcut icon" href="/static/images/favicon.ico" />
     <!-- Bootstrap core CSS -->
     <link type="text/css" rel="stylesheet" href="/static/plugins/bootstrap/css/bootstrap.min.css">


### PR DESCRIPTION
现有的网页标题只有 MM-Wiki ，区分度比较低。

本MR将其改为 {{.system_name}} | MM-Wiki，例如：袋鼠科技公司 ｜ MM-Wiki