### PR TITLE
添加系统URL，让管理员可以设置统一的访问链接，避免依赖于访问URL导致的安全问题

### DIFF
--- a/app/controllers/page.go
+++ b/app/controllers/page.go
@@ -255,10 +255,26 @@ func (this *PageController) Modify() {
 		this.jsonError("修改文档失败！")
 	}
 
+	// get system url
+	configs, err := models.ConfigModel.GetConfigs()
+	if err != nil {
+		this.ErrorLog("获取配置信息失败: " + err.Error())
+		this.jsonError("获取配置出错！")
+	}
+	var system_url string
+	for _, config := range configs {
+		if len(config) == 0 {
+			continue
+		}
+		if config["key"] == models.ConfigKeySystemUrl {
+			system_url = config["value"]
+		}
+	}
+
 	// send email to follow user
 	if isNoticeUser == "1" {
 		logInfo := this.GetLogInfoByCtx()
-		url := fmt.Sprintf("%s:%d/document/index?document_id=%s", this.Ctx.Input.Site(), this.Ctx.Input.Port(), documentId)
+		url := fmt.Sprintf("%s/document/index?document_id=%s", system_url, documentId)
 		go func(documentId string, username string, comment string, url string) {
 			err := sendEmail(documentId, username, comment, url)
 			if err != nil {

--- a/app/models/config.go
+++ b/app/models/config.go
@@ -17,6 +17,7 @@ const (
 	ConfigKeyFulltextSearch  = "fulltext_search_open"
 	ConfigKeyDocSearchTimer  = "doc_search_timer"
 	ConfigKeySystemName      = "system_name"
+	ConfigKeySystemUrl       = "system_url"
 )
 
 type Config struct {

--- a/app/modules/system/controllers/config.go
+++ b/app/modules/system/controllers/config.go
@@ -51,6 +51,7 @@ func (this *ConfigController) Modify() {
 	fulltextSearch := strings.TrimSpace(this.GetString(models.ConfigKeyFulltextSearch, "0"))
 	docSearchTimer := strings.TrimSpace(this.GetString(models.ConfigKeyDocSearchTimer, "3600"))
 	systemName := strings.TrimSpace(this.GetString(models.ConfigKeySystemName, "Markdown Mini Wiki"))
+	systemUrl := strings.TrimSpace(this.GetString(models.ConfigKeySystemUrl, "http://localhost:8080"))
 
 	if sendEmailOpen == "1" {
 		email, err := models.EmailModel.GetUsedEmail()
@@ -82,6 +83,7 @@ func (this *ConfigController) Modify() {
 		models.ConfigKeyFulltextSearch:  fulltextSearch,
 		models.ConfigKeyDocSearchTimer:  docSearchTimer,
 		models.ConfigKeySystemName:      systemName,
+		models.ConfigKeySystemUrl:       systemUrl,
 	}
 	// 有修改再更新
 	configs, err := models.ConfigModel.GetConfigs()

--- a/app/modules/system/controllers/email.go
+++ b/app/modules/system/controllers/email.go
@@ -314,6 +314,25 @@ func (this *EmailController) Test() {
 		"is_ssl":              isSsl,
 	}
 
+	configs, err := models.ConfigModel.GetConfigs()
+	if err != nil {
+		this.ErrorLog("获取配置信息失败: " + err.Error())
+		this.jsonError("获取配置出错！")
+	}
+	var system_name string
+	var system_url string
+	for _, config := range configs {
+		if len(config) == 0 {
+			continue
+		}
+		if config["key"] == models.ConfigKeySystemName {
+			system_name = config["value"]
+		}
+		if config["key"] == models.ConfigKeySystemUrl {
+			system_url = config["value"]
+		}
+	}
+
 	to := strings.Split(emails, ";")
 	documentValue := map[string]string{
 		"name":         "MM-Wiki测试邮件",
@@ -321,7 +340,7 @@ func (this *EmailController) Test() {
 		"update_time":  fmt.Sprintf("%d", time.Now().Unix()),
 		"comment":      "",
 		"document_url": "",
-		"content":      "欢迎使用 <a href='https://github.com/phachon/mm-wiki'>MM-Wiki</a>，这是一封测试邮件，请勿回复!",
+		"content":      fmt.Sprintf("欢迎使用 <a href='%s'>%s MM-Wiki</a>，这是一封测试邮件，请勿回复!", system_url, system_name),
 	}
 
 	emailTemplate := beego.BConfig.WebConfig.ViewsPath + "/system/email/template_test.html"

--- a/docs/databases/data.sql
+++ b/docs/databases/data.sql
@@ -166,3 +166,4 @@ INSERT INTO `mw_config` VALUES ('5', '是否开启统一登录', 'sso_open', '',
 INSERT INTO `mw_config` (name, `key`, value, create_time, update_time) VALUES ('开启全文搜索', 'fulltext_search_open', '1', unix_timestamp(now()), unix_timestamp(now()));
 INSERT INTO `mw_config` (name, `key`, value, create_time, update_time) VALUES ('索引更新间隔', 'doc_search_timer', '3600', unix_timestamp(now()), unix_timestamp(now()));
 INSERT INTO `mw_config` (name, `key`, value, create_time, update_time) VALUES ('系统名称', 'system_name', 'Markdown Mini Wiki', unix_timestamp(now()), unix_timestamp(now()));
+INSERT INTO `mw_config` (name, `key`, value, create_time, update_time) VALUES ('系统URL', 'system_url', 'http://localhost:8080', unix_timestamp(now()), unix_timestamp(now()));

--- a/views/system/config/form.html
+++ b/views/system/config/form.html
@@ -17,6 +17,12 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label class="col-sm-2 control-label"><span class="text-danger"> * </span>系统网址</label>
+                    <div class="col-sm-4">
+                        <input type="text" name="system_url" class="form-control" value="{{.configValue.system_url}}" placeholder="请输入系统网址，用于外部访问">
+                    </div>
+                </div>
+                <div class="form-group">
                     <label class="col-sm-2 control-label"><span class="text-danger"> * </span>主页标题</label>
                     <div class="col-sm-4">
                         <input type="text" name="main_title" class="form-control" value="{{.configValue.main_title}}" placeholder="请输入主页标题">


### PR DESCRIPTION
一个文档被修改时，现在产生的提醒邮件里的 “阅读文档” 按钮的 URL 通过 this.Ctx.Input.Site() 生成，这依赖于浏览器的访问URL

如果一个恶意用户在其本地修改 /etc/hosts，将 wiki 的 IP 重定位到一个恶意网址 http://xxx:1234 ，然后修改某个wiki页面，那么MM-Wiki 给关注该页面的用户发送邮件，邮件里会使用该恶意网址 http://xxx:1234/document/index?document_id=123 ，用户点击链接会去到 http://xxx:1234 ，然后可能会被钓鱼。

本 PR 允许管理员设置统一的访问链接，以解决依赖访问URL来获取wiki网址存在安全问题。