### PR TITLE
添加直接保存且不跳转页面功能

### DIFF
--- a/app/controllers/page.go
+++ b/app/controllers/page.go
@@ -179,6 +179,8 @@ func (this *PageController) Modify() {
 	comment := strings.TrimSpace(this.GetString("comment", ""))
 	isNoticeUser := strings.TrimSpace(this.GetString("is_notice_user", "0"))
 	isFollowDoc := strings.TrimSpace(this.GetString("is_follow_doc", "0"))
+	// 保存类型
+	saveType := strings.TrimSpace(this.GetString("save_type", ""))
 
 	// rm document_page_editor-markdown-doc
 	this.Ctx.Request.PostForm.Del("document_page_editor-markdown-doc")
@@ -281,7 +283,7 @@ func (this *PageController) Modify() {
 	}(documentId)
 
 	this.InfoLog("修改文档 " + documentId + " 成功")
-	this.jsonSuccess("文档修改成功！", nil, "/document/index?document_id="+documentId)
+	this.jsonSuccess("文档修改成功！", saveType, "/document/index?document_id="+documentId)
 }
 
 // document share display

--- a/static/js/modules/page.js
+++ b/static/js/modules/page.js
@@ -9,7 +9,7 @@ var Page = {
      * @param element
      * @returns {boolean}
      */
-    ajaxSave: function (element, sendEmail, isAutoFollow) {
+    ajaxSave: function (element, sendEmail, isAutoFollow, isConfirm) {
 
         /**
          * 成功信息条
@@ -45,12 +45,24 @@ var Page = {
                 Storage.remove(storageId);
                 successBox(result.message, result.data);
             }
-            if (result.redirect.url) {
+            if (result.redirect.url && result.data == "0") {
                 var sleepTime = result.redirect.sleep || 3000;
                 setTimeout(function () {
                     parent.location.href = result.redirect.url;
                 }, sleepTime);
             }
+        }
+
+        // 直接保存
+        if(isConfirm == false){
+            var commentText = ""
+            var options = {
+                dataType: 'json',
+                success: response,
+                data: {'comment': commentText, 'is_notice_user': "0", 'is_follow_doc': "1", 'save_type':"1"}
+            };
+            $(element).ajaxSubmit(options);
+            return false;
         }
 
         var containerHtml = '<div class="container-fluid" style="padding: 20px 20px 0 20px">';
@@ -95,7 +107,7 @@ var Page = {
                     var options = {
                         dataType: 'json',
                         success: response,
-                        data: {'comment': commentText, 'is_notice_user': isNoticeUser, 'is_follow_doc': isFollowDoc}
+                        data: {'comment': commentText, 'is_notice_user': isNoticeUser, 'is_follow_doc': isFollowDoc, 'save_type':"0"}
                     };
                     $(element).ajaxSubmit(options);
                 }

--- a/views/page/edit.html
+++ b/views/page/edit.html
@@ -8,7 +8,8 @@
                     <input type="text" name="name" class="form-control" placeholder="请输入文档名称" value="{{$document.name}}" {{if eq $document.parent_id "0"}} readonly="readonly" {{end}}>
                 </div>
                 <div class="col-md-2 text-center" >
-                    <button type="button" class="btn btn-primary" onclick="Page.ajaxSave(this.form, {{.sendEmail}}, {{.autoFollowDoc}})"><i class="fa fa-save"></i> 保存</button>
+                    <button type="button" class="btn btn-primary" onclick="Page.ajaxSave(this.form, {{.sendEmail}}, {{.autoFollowDoc}}, true)"><i class="fa fa-save"></i> 确认保存</button>
+                    <button type="button" class="btn btn-primary" onclick="Page.ajaxSave(this.form, {{.sendEmail}}, {{.autoFollowDoc}}, false)"><i class="fa fa-save"></i> 直接保存</button>
                     <button type="button" class="btn btn-default" onclick="Page.cancelSave('确定要放弃此次修改吗?', '/document/index?document_id={{$document.document_id}}')"><i class="fa fa-mail-reply"></i> 取消</button>
                 </div>
             </div>


### PR DESCRIPTION
1. 修改“保存”按钮为“确认保存”。
2. 添加“直接保存”按钮。
3. 直接保存成功后不跳转页面。
